### PR TITLE
Fix cross-filesystem move, and add custom docset support

### DIFF
--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -229,10 +229,11 @@ void Plugin::downloadDocset(uint index)
 
     connect(download_, &QNetworkReply::finished, this, [this, &ds]
     {
+        auto docsetDir = QDir(docsetsLocation());
         if (download_)  // else aborted
         {
             debug(tr("Download finished."));
-            if (auto tmp_dir = QTemporaryDir();
+            if (auto tmp_dir = QTemporaryDir(docsetDir.filePath(u"extractXXXXXX"_s));
                 tmp_dir.isValid())
             {
                 // write downloaded data to file
@@ -253,8 +254,7 @@ void Plugin::downloadDocset(uint index)
                             it.hasNext())
                         {
                             auto src = it.next();
-                            auto dst = QDir(docsetsLocation())
-                                           .filePath(u"%1.docset"_s.arg(ds.name));
+                            auto dst = docsetDir.filePath(u"%1.docset"_s.arg(ds.name));
                             debug(tr("Renaming '%1' to '%2'").arg(src, dst));
                             if (QFile::rename(src, dst))
                             {

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -36,6 +36,7 @@ private:
     void debug(const QString &);
     void error(const QString &, QWidget *modal_parent = nullptr);
     std::filesystem::path docsetsLocation() const;
+    std::filesystem::path customDocsetsLocation() const;
     std::filesystem::path iconsLocation() const;
 
     std::vector<Docset> docsets_;


### PR DESCRIPTION
Hello! This has two changes, which I can split up if you want to review them separately. First is a fix for #1, taking your approach of extracting the docset into the docset directory. Thankfully `QTemporaryDirectory` allows specifying a custom temporary pattern, so we can specify where we want the temporary directory, while still getting the rest of the semantics (auto deletion) for free.

The second change is a much nicer way of approaching albertlauncher/plugins#133: "custom docsets". I'd like to be able to browse docsets that aren't part of the Zeal collection. So I add a second directory where you can place any directory named `*.docset` which contains an icon. Albert detects these and includes them in the collection of docsets.